### PR TITLE
update to newer prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ const gulp = require('gulp'),
 
 gulp.task('default', () => {
 	gulp.src('*.js')
-	.pipe(prettier({useFlowParser: true}))
+	.pipe(prettier({parser: 'flow'}))
 	.pipe(gulp.dest('./dist'))
 });
 ```
@@ -30,14 +30,14 @@ Please consult the [Prettier](https://github.com/jlongster/prettier) README to k
   // Number of spaces it should use per tab
   tabWidth: 2,
 
-  // Use the flow parser instead of babylon
-  useFlowParser: false,
+  // Use the babylon parser instead of flow
+  parser: 'babylon,
 
   // If true, will use single instead of double quotes
   singleQuote: false,
 
   // Controls the printing of trailing commas wherever possible
-  trailingComma: false,
+  trailingComma: 'none',
 
   // Controls the printing of spaces inside array and objects
   bracketSpacing: true

--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ module.exports = function(opt) {
         printWidth: 80,
         // Number of spaces it should use per tab
         tabWidth: 2,
-        // Use the flow parser instead of babylon
-        useFlowParser: true,
+        // Use the babylon parser instead of flow
+        parser: 'babylon',
         // If true, will use single instead of double quotes
         singleQuote: false,
         // Controls the printing of trailing commas wherever possible
-        trailingComma: false,
+        trailingComma: 'none',
         // Controls the printing of spaces inside array and objects
         bracketSpacing: true
       },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   ],
   "author": "Bhargav R. Patel",
   "license": "MIT",
+  "peerDependencies": {
+    "prettier": "^0.22.0"
+  },
   "dependencies": {
     "gulp-util": "^3.0.8",
     "merge": "^1.2.0",
-    "prettier": "0.0.7",
     "through2": "^2.0.3",
     "vinyl-sourcemaps-apply": "^0.2.1"
   }


### PR DESCRIPTION
Newer versions of Prettier are quite a bit different. I made a few changes:

 * I switched Prettier to a peer dependency. I'm not certain, but I think that's the more appropriate relationship, since the caller may have other uses for prettier (specifically, I also plug it into ESLint) and it's crucial that everything be running the same version of Prettier.
 * Prettier has made some API changes. Specifically, some of the options have changed.
 * Babylon is the default parser for Prettier, not flow, so use that by default