### PR TITLE
refactor: replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 'use strict';
 const through = require('through2'),
-  gutil = require('gulp-util'),
+  PluginError = require('plugin-error'),
   prettier = require('prettier'),
   merge = require('merge'),
   applySourceMap = require('vinyl-sourcemaps-apply');
-
-var PluginError = gutil.PluginError;
 
 module.exports = function(opt) {
   function transform(file, encoding, callback) {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "author": "Bhargav R. Patel",
   "license": "MIT",
   "dependencies": {
-    "gulp-util": "^3.0.8",
     "merge": "^1.2.0",
+    "plugin-error": "^1.0.1",
     "prettier": "^1.5.3",
     "through2": "^2.0.3",
     "vinyl-sourcemaps-apply": "^0.2.1"


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp.

The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143