### PR TITLE
feat: support editorconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Type: `Object`
 
 Consult the Prettier [options](https://prettier.io/docs/en/options.html).
 
+`editorconfig: true` can also be passed to enable [EditorConfig support](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath-options).
+
 ### prettier.check([options])
 
 Checks if your files have been formatted with Prettier and, if not, throws an error with a list of unformatted files. This is useful for running Prettier in CI scenarios.
@@ -60,6 +62,8 @@ Checks if your files have been formatted with Prettier and, if not, throws an er
 Type: `Object`
 
 Consult the Prettier [options](https://prettier.io/docs/en/options.html).
+
+`editorconfig: true` can also be passed to enable [EditorConfig support](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath-options).
 
 ## Collaborators
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(options) {
       return callback(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
     }
 
-    const config = prettier.resolveConfig.sync(file.path);
+    const config = prettier.resolveConfig.sync(file.path, options);
     const fileOptions = Object.assign({}, config, options, {
       filepath: file.path
     });
@@ -60,7 +60,7 @@ module.exports.check = function(options) {
         );
       }
 
-      const config = prettier.resolveConfig.sync(file.path);
+      const config = prettier.resolveConfig.sync(file.path, options);
       const fileOptions = Object.assign({}, config, options, {
         filepath: file.path
       });

--- a/test/fixtures/.editorconfig
+++ b/test/fixtures/.editorconfig
@@ -1,0 +1,2 @@
+[config.js]
+indent_style = tab

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -190,6 +190,33 @@ describe('gulp-prettier', () => {
 
     stream.write(file);
   });
+
+  it('should support editorconfig', done => {
+    const options = { editorconfig: true };
+
+    const stream = plugin(options);
+
+    const input = 'function foo() { console.log("bar"); }';
+
+    const file = new Vinyl({
+      cwd: process.cwd(),
+      base: path.join(__dirname, 'fixtures'),
+      path: path.join(__dirname, 'fixtures', 'config.js'),
+      contents: Buffer.from(input)
+    });
+
+    stream.once('data', file => {
+      assert.ok(file.isBuffer());
+      assert.strictEqual(file.relative, 'config.js');
+      assert.strictEqual(
+        file.contents.toString('utf8'),
+        "function foo() {\n\tconsole.log('bar')\n}\n"
+      );
+      done();
+    });
+
+    stream.write(file);
+  });
 });
 
 describe('gulp-prettier.check', () => {


### PR DESCRIPTION
Optionally support EditorConfig, disabled by default. To enable, add `editorconfig: true` to the options passed to `gulp-prettier`.

Fixes #16.